### PR TITLE
fix overlapping of product cards on firefox

### DIFF
--- a/frontend/src/components/ProductCard.jsx
+++ b/frontend/src/components/ProductCard.jsx
@@ -38,7 +38,7 @@ export default function ProductCard({ product, onAdd, onImageUpload }) {
   /* ---------- 描画 ---------- */
   return (
     <div
-      className="group relative overflow-hidden rounded-3xl
+      className="group relative rounded-3xl
                  bg-gray-800/50 backdrop-blur-md shadow-glass
                  p-4 flex flex-col gap-3 hover:scale-[1.03] transition"
     >


### PR DESCRIPTION
firefox での表示がおかしかったので直したが，pushし忘れてたのでマージするお